### PR TITLE
Utilize Lock API when targeting .NET 9+

### DIFF
--- a/src/MinimalWorker/BackgroundWorkerExtensions.cs
+++ b/src/MinimalWorker/BackgroundWorkerExtensions.cs
@@ -66,7 +66,12 @@ public static partial class BackgroundWorkerExtensions
     public static readonly List<WorkerRegistration> _registrations = new();
     private static int _registrationCounter = 0;
     private static bool _isInitialized = false;
-    private static readonly object _lock = new();
+
+    #if NET9_0_OR_GREATER
+        private static readonly Lock _lock = new();
+    #else
+        private static readonly object _lock = new();
+    #endif
 
     /// <summary>
     /// Internal flag to control whether to use Environment.Exit on validation failure.


### PR DESCRIPTION
This PR addresses the following feature: #4 

Changes:

- Added an `#if` directive to check if the project is currently targeting .NET 9 or greater:
  - If .NET 9+ then utilize the `Lock` api
  - If less than .NET 9 is targeted then continue to use `object` as the "lock" 

Testing:
- Ran unit tests whilst targeting .NET 8 and all tests pass
- Ran unit tests whilst targeting .NET 9 & 10 and all tests pass