### PR TITLE
(Claude Code Test) Add dependency injection support to error handlers

### DIFF
--- a/src/MinimalWorker.Generators/WorkerEmitter.cs
+++ b/src/MinimalWorker.Generators/WorkerEmitter.cs
@@ -481,7 +481,11 @@ internal static class WorkerEmitter
         sb.AppendLine("                        // Log error");
         sb.AppendLine("                        if (workerLogger != null) WorkerLogMessages.WorkerExecutionFailedWithIteration(workerLogger, workerName, iteration, ex);");
         sb.AppendLine();
-        sb.AppendLine("                        if (registration.OnError != null)");
+        sb.AppendLine("                        if (registration.OnErrorWithServices != null)");
+        sb.AppendLine("                        {");
+        sb.AppendLine("                            registration.OnErrorWithServices(ex, scope.ServiceProvider);");
+        sb.AppendLine("                        }");
+        sb.AppendLine("                        else if (registration.OnError != null)");
         sb.AppendLine("                        {");
         sb.AppendLine("                            registration.OnError(ex);");
         sb.AppendLine("                        }");
@@ -619,7 +623,11 @@ internal static class WorkerEmitter
         sb.AppendLine("                        // Log error");
         sb.AppendLine("                        if (workerLogger != null) WorkerLogMessages.WorkerExecutionFailed(workerLogger, workerName, ex);");
         sb.AppendLine();
-        sb.AppendLine("                        if (registration.OnError != null)");
+        sb.AppendLine("                        if (registration.OnErrorWithServices != null)");
+        sb.AppendLine("                        {");
+        sb.AppendLine("                            registration.OnErrorWithServices(ex, scope.ServiceProvider);");
+        sb.AppendLine("                        }");
+        sb.AppendLine("                        else if (registration.OnError != null)");
         sb.AppendLine("                        {");
         sb.AppendLine("                            registration.OnError(ex);");
         sb.AppendLine("                        }");
@@ -777,7 +785,11 @@ internal static class WorkerEmitter
         sb.AppendLine("                        // Log error");
         sb.AppendLine("                        if (workerLogger != null) WorkerLogMessages.WorkerExecutionFailed(workerLogger, workerName, ex);");
         sb.AppendLine();
-        sb.AppendLine("                        if (registration.OnError != null)");
+        sb.AppendLine("                        if (registration.OnErrorWithServices != null)");
+        sb.AppendLine("                        {");
+        sb.AppendLine("                            registration.OnErrorWithServices(ex, scope.ServiceProvider);");
+        sb.AppendLine("                        }");
+        sb.AppendLine("                        else if (registration.OnError != null)");
         sb.AppendLine("                        {");
         sb.AppendLine("                            registration.OnError(ex);");
         sb.AppendLine("                        }");

--- a/src/MinimalWorker/BackgroundWorkerExtensions.cs
+++ b/src/MinimalWorker/BackgroundWorkerExtensions.cs
@@ -23,6 +23,15 @@ public interface IWorkerBuilder
     /// <param name="handler">The error handler delegate.</param>
     /// <returns>The builder instance for method chaining.</returns>
     IWorkerBuilder WithErrorHandler(Action<Exception> handler);
+
+    /// <summary>
+    /// Sets an error handler with dependency injection support for unhandled exceptions in the worker.
+    /// The service provider is scoped to the current worker execution.
+    /// If not provided, exceptions will cause the application to terminate.
+    /// </summary>
+    /// <param name="handler">The error handler delegate that receives the exception and a service provider.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    IWorkerBuilder WithErrorHandler(Action<Exception, IServiceProvider> handler);
 }
 
 /// <summary>
@@ -46,6 +55,12 @@ internal class WorkerBuilder : IWorkerBuilder
     public IWorkerBuilder WithErrorHandler(Action<Exception> handler)
     {
         _registration.OnError = handler;
+        return this;
+    }
+
+    public IWorkerBuilder WithErrorHandler(Action<Exception, IServiceProvider> handler)
+    {
+        _registration.OnErrorWithServices = handler;
         return this;
     }
 }
@@ -379,6 +394,7 @@ public static partial class BackgroundWorkerExtensions
         public IHost Host { get; set; } = null!;
         public int ParameterCount { get; set; } // Number of parameters in the delegate
         public Action<Exception>? OnError { get; set; } // Optional error handler
+        public Action<Exception, IServiceProvider>? OnErrorWithServices { get; set; } // Optional error handler with DI support
         public string Signature { get; set; } = string.Empty; // Unique signature based on parameter types
 
         /// <summary>


### PR DESCRIPTION
Implements native DI support for error handlers, addressing the limitation mentioned in the README. Error handlers can now receive an IServiceProvider parameter to resolve services, including scoped services.

Changes:
- Add WithErrorHandler(Action<Exception, IServiceProvider>) overload to IWorkerBuilder
- Add OnErrorWithServices field to WorkerRegistration class
- Update code generator to invoke DI-enabled error handlers for continuous, periodic, and cron workers
- Add comprehensive tests for DI-enabled error handlers across all worker types
- Update README.md to document the new feature and remove the workaround note

The original WithErrorHandler(Action<Exception>) signature is still supported for backwards compatibility.